### PR TITLE
Add deploy workflow with zip release on tag push

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,15 @@
+.claude
+.editorconfig
+.git
+.github
+.gitignore
+.husky
+.mcp.json
+.wp-env.json
+node_modules
+package.json
+package-lock.json
+phpcs.ruleset.xml
+phpunit.xml.dist
+tests
+wp

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,76 @@
+name: Deploy Plugin
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+
+  tags-check:
+    name: Check tagged branch
+    if: contains(github.ref, 'tags/')
+    uses: tarosky/workflows/.github/workflows/check-tag-in-branch.yml@main
+    with:
+      allowed_branch: "main"
+
+  release:
+    name: Create Release
+    needs: tags-check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP with composer v2
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+          tools: composer
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: composer install --no-dev --prefer-dist --no-progress
+
+      - name: Set version
+        run: |
+          PREFIX="refs/tags/"
+          VERSION=${GITHUB_REF#"$PREFIX"}
+          sed -i "s/Version: .*/Version: ${VERSION}/g" ./boswell.php
+
+      - name: Clean package
+        run: |
+          while IFS= read -r item; do
+            [ -z "$item" ] && continue
+            [ -e "$item" ] && rm -rf "$item"
+          done < .distignore
+
+      - name: Zip Archive
+        run: |
+          mkdir ${{ github.event.repository.name }}
+          rsync -av --exclude=${{ github.event.repository.name }} --exclude=.git ./ ./${{ github.event.repository.name }}/
+          zip -r ./${{ github.event.repository.name }}.zip ./${{ github.event.repository.name }}
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/${{ github.event.repository.name }}.zip
+          asset_name: ${{ github.event.repository.name }}.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
Creates a GitHub Release with plugin zip when a version tag is pushed. Uses .distignore to exclude dev files from the archive.