### PR TITLE
Add version resolver to release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,5 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
 categories:
   - title: 'Features'
     labels:
@@ -12,6 +14,19 @@ categories:
     labels:
       - 'chore'
       - 'dependencies'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
 template: |
   ## Changes
 


### PR DESCRIPTION
## Summary
- Add `name-template`, `tag-template`, and `version-resolver` to release-drafter config
- Release drafts will now auto-increment version numbers based on PR labels (major/minor/patch, default: patch)
- Uses `$RESOLVED_VERSION` without `v` prefix to match deploy workflow tag pattern (`*.*.*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)