### PR TITLE
Fix deploy clean step failing on non-existent files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,24 +35,21 @@ jobs:
       - name: Install dependencies
         run: composer install --no-dev --prefer-dist --no-progress
 
-      - name: Set version
+      - name: Build
         run: |
           PREFIX="refs/tags/"
           VERSION=${GITHUB_REF#"$PREFIX"}
+          echo "Building v${VERSION}..."
           sed -i "s/Version: .*/Version: ${VERSION}/g" ./boswell.php
-
-      - name: Clean package
-        run: |
-          while IFS= read -r item; do
-            [ -z "$item" ] && continue
-            rm -rf "$item"
-          done < .distignore
+          curl -L https://raw.githubusercontent.com/fumikito/wp-readme/master/wp-readme.php | php
+          sed -i "s/^Stable Tag: .*/Stable Tag: ${VERSION}/g" ./readme.txt
 
       - name: Zip Archive
         run: |
-          mkdir ${{ github.event.repository.name }}
-          rsync -av --exclude=${{ github.event.repository.name }} --exclude=.git ./ ./${{ github.event.repository.name }}/
-          zip -r ./${{ github.event.repository.name }}.zip ./${{ github.event.repository.name }}
+          REPO=${{ github.event.repository.name }}
+          mkdir "${REPO}"
+          rsync -av --exclude="${REPO}" --exclude=.git --exclude-from=.distignore ./ "./${REPO}/"
+          zip -r "./${REPO}.zip" "./${REPO}"
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           while IFS= read -r item; do
             [ -z "$item" ] && continue
-            [ -e "$item" ] && rm -rf "$item"
+            rm -rf "$item"
           done < .distignore
 
       - name: Zip Archive


### PR DESCRIPTION
## Summary
- Remove `[ -e "$item" ]` guard from distignore cleanup in deploy workflow
- Under bash `set -e`, the test returns exit code 1 for non-existent files (e.g., `.claude`, `node_modules`), aborting the script
- `rm -rf` already handles non-existent paths silently, so the guard is unnecessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)