### PR TITLE
Fix deploy: upload zip to existing release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,23 +51,9 @@ jobs:
           rsync -av --exclude="${REPO}" --exclude=.git --exclude-from=.distignore ./ "./${REPO}/"
           zip -r "./${REPO}.zip" "./${REPO}"
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-
       - name: Upload release asset
-        uses: actions/upload-release-asset@v1.0.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/${{ github.event.repository.name }}.zip
-          asset_name: ${{ github.event.repository.name }}.zip
-          asset_content_type: application/zip
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          gh release upload "${TAG}" "${{ github.event.repository.name }}.zip" --clobber


### PR DESCRIPTION
## Summary
- Replace `actions/create-release` + `actions/upload-release-asset` with `gh release upload --clobber`
- Release-drafter already creates the release; deploy workflow just needs to attach the zip
- Fixes "Validation Failed" error when release already exists for the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)