### PR TITLE
Add strategy-based post selection and comment safety valve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ package-lock.json
 
 # Build files
 /wp/
+/wiki/
 
 # AI
 .claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ Go to **Settings > Boswell** in the WordPress admin. Each persona needs an ID, d
 
 Yes. Each persona can have a cron schedule (e.g., daily). Boswell will automatically find eligible posts and generate comments.
 
+### How do I customize comment strategies?
+
+See the [Wiki](https://github.com/hametuha/boswell/wiki) for details on adding custom strategies, adjusting query parameters, enriching post context, and blocking comments on specific posts or categories.
+
 ## Changelog
 
 ### 0.1.0

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Boswell
 
-Tags: ai, comments, persona, mcp, content
-Contributors: Takahashi_Fumiki
-Tested Up to: 6.9
-Stable Tag: 0.1.0
-Requires at least: 6.9
-Requires PHP: 8.1
-License: GPLv3 or later
+Tags: ai, comments, persona, mcp, content  
+Contributors: hametuha, Takahashi_Fumiki  
+Tested Up to: 6.9  
+Stable Tag: 0.1.0  
+Requires at least: 6.9  
+Requires PHP: 8.1  
+License: GPLv3 or later  
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 AI-powered commenting and content management for WordPress.
@@ -49,6 +49,8 @@ Boswell uses [wp-ai-client](https://github.com/WordPress/wp-ai-client) for AI te
 - [AI Provider for Anthropic](https://github.com/WordPress/ai-provider-for-anthropic) (bundled)
 - [AI Provider for OpenAI](https://github.com/WordPress/openai-ai-provider) (optional)
 - [AI Provider for Google](https://github.com/WordPress/google-ai-provider) (optional)
+
+Since WordPress 7.0, these extensions above will not be bundled.
 
 ## Installation
 

--- a/boswell.php
+++ b/boswell.php
@@ -27,6 +27,7 @@ require_once __DIR__ . '/includes/class-memory.php';
 require_once __DIR__ . '/includes/class-persona.php';
 require_once __DIR__ . '/includes/class-persona-admin.php';
 require_once __DIR__ . '/includes/class-commenter.php';
+require_once __DIR__ . '/includes/class-strategy-selector.php';
 require_once __DIR__ . '/includes/class-cron.php';
 require_once __DIR__ . '/includes/class-rest-controller.php';
 require_once __DIR__ . '/includes/class-abilities.php';

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -103,20 +103,25 @@ class Boswell_CLI extends WP_CLI_Command {
 	 * [--persona=<persona_id>]
 	 * : Run for a specific persona. If omitted, runs all cron-enabled personas.
 	 *
+	 * [--strategy=<strategy_id>]
+	 * : Use a specific strategy. If omitted, picks randomly by weight.
+	 * Use `wp boswell strategies` to list available strategies.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp boswell run
 	 *     wp boswell run --persona=persona
+	 *     wp boswell run --persona=persona --strategy=book_review
 	 *
 	 * @param array<int, string>    $args       Positional arguments.
 	 * @param array<string, string> $assoc_args Named arguments.
 	 */
 	public function run( array $args, array $assoc_args ): void {
-		$persona_id = $assoc_args['persona'] ?? '';
+		$persona_id  = $assoc_args['persona'] ?? '';
+		$strategy_id = $assoc_args['strategy'] ?? '';
 
 		if ( ! empty( $persona_id ) ) {
-			// Single persona mode.
-			self::run_single( $persona_id );
+			self::run_single( $persona_id, $strategy_id );
 			return;
 		}
 
@@ -129,19 +134,24 @@ class Boswell_CLI extends WP_CLI_Command {
 		}
 
 		foreach ( $enabled as $p ) {
-			self::run_single( $p['id'] );
+			self::run_single( $p['id'], $strategy_id );
 		}
 	}
 
 	/**
 	 * Run auto-comment for a single persona and display the result.
 	 *
-	 * @param string $persona_id Persona ID.
+	 * @param string $persona_id  Persona ID.
+	 * @param string $strategy_id Optional strategy ID.
 	 */
-	private static function run_single( string $persona_id ): void {
-		WP_CLI::log( sprintf( 'Running auto-comment as "%s"...', $persona_id ) );
+	private static function run_single( string $persona_id, string $strategy_id = '' ): void {
+		if ( ! empty( $strategy_id ) ) {
+			WP_CLI::log( sprintf( 'Running auto-comment as "%s" with strategy "%s"...', $persona_id, $strategy_id ) );
+		} else {
+			WP_CLI::log( sprintf( 'Running auto-comment as "%s"...', $persona_id ) );
+		}
 
-		$result = Boswell_Cron::run( $persona_id );
+		$result = Boswell_Cron::run( $persona_id, $strategy_id );
 
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::warning( sprintf( '[%s] %s', $persona_id, $result->get_error_message() ) );

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -163,6 +163,47 @@ class Boswell_CLI extends WP_CLI_Command {
 	}
 
 	/**
+	 * List registered comment strategies.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format. Accepts table, json, csv, yaml. Default: table.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp boswell strategies
+	 *     wp boswell strategies --format=json
+	 *
+	 * @param array<int, string>    $args       Positional arguments.
+	 * @param array<string, string> $assoc_args Named arguments.
+	 */
+	public function strategies( array $args, array $assoc_args ): void {
+		$strategies = Boswell_Strategy_Selector::get_strategies();
+
+		if ( empty( $strategies ) ) {
+			WP_CLI::warning( 'No strategies registered.' );
+			return;
+		}
+
+		$total = array_sum( array_column( $strategies, 'weight' ) );
+		$items = array();
+		foreach ( $strategies as $s ) {
+			$weight  = max( 1, (int) ( $s['weight'] ?? 1 ) );
+			$items[] = array(
+				'id'          => $s['id'] ?? '(none)',
+				'label'       => $s['label'] ?? '',
+				'weight'      => $weight,
+				'probability' => $total > 0 ? round( $weight / $total * 100 ) . '%' : '—',
+				'hint'        => mb_strimwidth( $s['hint'] ?? '', 0, 60, '...' ),
+			);
+		}
+
+		$format = $assoc_args['format'] ?? 'table';
+		WP_CLI\Utils\format_items( $format, $items, array( 'id', 'label', 'weight', 'probability', 'hint' ) );
+	}
+
+	/**
 	 * Show Boswell's memory, narrated by a persona.
 	 *
 	 * ## OPTIONS

--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -78,10 +78,11 @@ class Boswell_Cron {
 	/**
 	 * Execute one comment cycle: select a post and comment on it.
 	 *
-	 * @param string $persona_id The persona to comment as.
+	 * @param string $persona_id  The persona to comment as.
+	 * @param string $strategy_id Optional strategy ID. If empty, picks randomly by weight.
 	 * @return WP_Comment|WP_Error The posted comment or error.
 	 */
-	public static function run( string $persona_id ) {
+	public static function run( string $persona_id, string $strategy_id = '' ) {
 		if ( empty( $persona_id ) ) {
 			return new WP_Error( 'boswell_no_persona', __( 'No persona specified.', 'boswell' ) );
 		}
@@ -92,7 +93,7 @@ class Boswell_Cron {
 		}
 
 		// Strategy-based selection.
-		$result  = Boswell_Strategy_Selector::select( $persona );
+		$result  = Boswell_Strategy_Selector::select( $persona, $strategy_id );
 		$post_id = $result['post_id'];
 		$context = $result['context'];
 

--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -20,11 +20,10 @@ class Boswell_Cron {
 	const FREQUENCIES = array( 'hourly', 'twicedaily', 'daily' );
 
 	/**
-	 * Register the cron handler and default post selection filter.
+	 * Register the cron handler.
 	 */
 	public static function init(): void {
 		add_action( self::HOOK_NAME, array( __CLASS__, 'handle' ) );
-		add_filter( 'boswell_select_post', array( __CLASS__, 'select_post' ), 10, 2 );
 	}
 
 	/**
@@ -97,67 +96,11 @@ class Boswell_Cron {
 		$post_id = $result['post_id'];
 		$context = $result['context'];
 
-		// Legacy fallback for existing boswell_select_post filter users.
-		if ( empty( $post_id ) ) {
-			/**
-			 * Select a post to comment on.
-			 *
-			 * @deprecated Use boswell_comment_strategies filter instead.
-			 *
-			 * @param int                  $post_id Default 0 (no post).
-			 * @param array<string, mixed> $persona Persona data.
-			 * @return int Post ID, or 0 if none found.
-			 */
-			$post_id = apply_filters( 'boswell_select_post', 0, $persona );
-			$context = array();
-		}
-
 		if ( empty( $post_id ) ) {
 			return new WP_Error( 'boswell_no_post', __( 'No eligible post found to comment on.', 'boswell' ) );
 		}
 
 		return Boswell_Commenter::comment( $post_id, $persona_id, 0, $context );
-	}
-
-	/**
-	 * Default post selection: random recent post not yet commented by the persona's user.
-	 *
-	 * @deprecated Use Boswell_Strategy_Selector::select() and boswell_comment_strategies filter.
-	 *
-	 * @param int                  $post_id Current post ID (0 if none selected yet).
-	 * @param array<string, mixed> $persona Persona data.
-	 * @return int Post ID.
-	 */
-	public static function select_post( int $post_id, array $persona ): int {
-		// If another filter already selected a post, don't override.
-		if ( $post_id > 0 ) {
-			return $post_id;
-		}
-
-		global $wpdb;
-
-		$user_id = (int) $persona['user_id'];
-
-		// Get recent published post IDs not commented by this user.
-		// Uses post_date_gmt + UTC_TIMESTAMP() for timezone-safe comparison.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- One-off selection query.
-		$results = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT p.ID FROM {$wpdb->posts} p
-				WHERE p.post_type = 'post'
-				AND p.post_status = 'publish'
-				AND p.post_date_gmt >= DATE_SUB( UTC_TIMESTAMP(), INTERVAL 90 DAY )
-				AND p.ID NOT IN (
-					SELECT DISTINCT comment_post_ID FROM {$wpdb->comments}
-					WHERE user_id = %d
-				)
-				ORDER BY RAND()
-				LIMIT 1",
-				$user_id
-			)
-		);
-
-		return ! empty( $results ) ? (int) $results[0] : 0;
 	}
 
 	/**

--- a/includes/class-strategy-selector.php
+++ b/includes/class-strategy-selector.php
@@ -15,10 +15,11 @@ class Boswell_Strategy_Selector {
 	/**
 	 * Select a post for a persona using the strategy system.
 	 *
-	 * @param array<string, mixed> $persona Persona data.
+	 * @param array<string, mixed> $persona     Persona data.
+	 * @param string               $strategy_id Optional strategy ID. If empty, picks randomly by weight.
 	 * @return array{post_id: int, context: array<string, mixed>}
 	 */
-	public static function select( array $persona ): array {
+	public static function select( array $persona, string $strategy_id = '' ): array {
 		$strategies = self::get_strategies();
 
 		if ( empty( $strategies ) ) {
@@ -28,8 +29,25 @@ class Boswell_Strategy_Selector {
 			);
 		}
 
-		$strategy = self::pick_weighted( $strategies );
-		$args     = self::build_query_args( $strategy );
+		// Pick a specific strategy or random by weight.
+		$strategy = null;
+		if ( ! empty( $strategy_id ) ) {
+			foreach ( $strategies as $s ) {
+				if ( ( $s['id'] ?? '' ) === $strategy_id ) {
+					$strategy = $s;
+					break;
+				}
+			}
+			if ( ! $strategy ) {
+				return array(
+					'post_id' => 0,
+					'context' => array(),
+				);
+			}
+		} else {
+			$strategy = self::pick_weighted( $strategies );
+		}
+		$args = self::build_query_args( $strategy );
 
 		/**
 		 * Filter the WP_Query arguments before execution.

--- a/includes/class-strategy-selector.php
+++ b/includes/class-strategy-selector.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Boswell Strategy Selector
+ *
+ * Selects a post using weighted-random strategy picking and WP_Query.
+ *
+ * @package Boswell
+ */
+
+/**
+ * Strategy-based post selection for automatic commenting.
+ */
+class Boswell_Strategy_Selector {
+
+	/**
+	 * Select a post for a persona using the strategy system.
+	 *
+	 * @param array<string, mixed> $persona Persona data.
+	 * @return array{post_id: int, context: array<string, mixed>}
+	 */
+	public static function select( array $persona ): array {
+		$strategies = self::get_strategies();
+
+		if ( empty( $strategies ) ) {
+			return array(
+				'post_id' => 0,
+				'context' => array(),
+			);
+		}
+
+		$strategy = self::pick_weighted( $strategies );
+		$args     = self::build_query_args( $strategy );
+
+		/**
+		 * Filter the WP_Query arguments before execution.
+		 *
+		 * @param array<string, mixed> $args     WP_Query arguments.
+		 * @param array<string, mixed> $strategy The selected strategy.
+		 * @param array<string, mixed> $persona  Persona data.
+		 */
+		$args = apply_filters( 'boswell_select_post_args', $args, $strategy, $persona );
+
+		// Inject exclusion AFTER the filter so it cannot be removed.
+		$args = self::exclude_commented_posts( $args, $persona );
+
+		$query = new WP_Query( $args );
+
+		if ( ! $query->have_posts() ) {
+			return array(
+				'post_id' => 0,
+				'context' => array(),
+			);
+		}
+
+		$post    = $query->posts[0];
+		$context = self::build_context( $post, $strategy );
+
+		return array(
+			'post_id' => $post->ID,
+			'context' => $context,
+		);
+	}
+
+	/**
+	 * Get all strategies (default + filtered).
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function get_strategies(): array {
+		$defaults = array(
+			array(
+				'id'         => 'recent',
+				'label'      => __( 'Recent posts', 'boswell' ),
+				'weight'     => 1,
+				'query_args' => array(
+					'date_query' => array( array( 'after' => '90 days ago' ) ),
+					'orderby'    => 'rand',
+				),
+				'hint'       => __( 'A recently published post.', 'boswell' ),
+			),
+		);
+
+		/**
+		 * Filter available comment strategies.
+		 *
+		 * Each strategy is an array with:
+		 *   - id         (string) Unique identifier.
+		 *   - label      (string) Human-readable label.
+		 *   - weight     (int)    Selection weight (higher = more likely).
+		 *   - query_args (array)  WP_Query arguments.
+		 *   - hint       (string) Context hint passed to the AI prompt.
+		 *
+		 * @param array<int, array<string, mixed>> $strategies Default strategies.
+		 */
+		return apply_filters( 'boswell_comment_strategies', $defaults );
+	}
+
+	/**
+	 * Pick a strategy using weighted random selection.
+	 *
+	 * @param array<int, array<string, mixed>> $strategies Available strategies.
+	 * @return array<string, mixed> The chosen strategy.
+	 */
+	public static function pick_weighted( array $strategies ): array {
+		$total = array_sum( array_column( $strategies, 'weight' ) );
+		$roll  = wp_rand( 1, max( 1, $total ) );
+
+		$cumulative = 0;
+		foreach ( $strategies as $strategy ) {
+			$cumulative += max( 1, (int) ( $strategy['weight'] ?? 1 ) );
+			if ( $roll <= $cumulative ) {
+				return $strategy;
+			}
+		}
+
+		return $strategies[0];
+	}
+
+	/**
+	 * Build WP_Query arguments from a strategy.
+	 *
+	 * @param array<string, mixed> $strategy Strategy data.
+	 * @return array<string, mixed>
+	 */
+	private static function build_query_args( array $strategy ): array {
+		$args = $strategy['query_args'] ?? array();
+
+		$args['post_type']      = 'post';
+		$args['post_status']    = 'publish';
+		$args['posts_per_page'] = 1;
+
+		return $args;
+	}
+
+	/**
+	 * Inject post__not_in for posts already commented by the persona's user.
+	 *
+	 * Runs AFTER boswell_select_post_args to ensure it cannot be removed.
+	 *
+	 * @param array<string, mixed> $args    WP_Query arguments.
+	 * @param array<string, mixed> $persona Persona data.
+	 * @return array<string, mixed>
+	 */
+	private static function exclude_commented_posts( array $args, array $persona ): array {
+		global $wpdb;
+
+		$user_id = (int) $persona['user_id'];
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- One-off selection query.
+		$commented_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT DISTINCT comment_post_ID FROM {$wpdb->comments} WHERE user_id = %d",
+				$user_id
+			)
+		);
+
+		if ( ! empty( $commented_ids ) ) {
+			$existing             = $args['post__not_in'] ?? array();
+			$args['post__not_in'] = array_merge( $existing, array_map( 'intval', $commented_ids ) );
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Build post context from strategy hint and filter.
+	 *
+	 * @param WP_Post              $post     The selected post.
+	 * @param array<string, mixed> $strategy The strategy that selected it.
+	 * @return array<string, mixed>
+	 */
+	private static function build_context( WP_Post $post, array $strategy ): array {
+		$context = array(
+			'strategy_id'   => $strategy['id'] ?? 'unknown',
+			'strategy_hint' => $strategy['hint'] ?? '',
+			'notes'         => array(),
+		);
+
+		/**
+		 * Filter the post context after selection.
+		 *
+		 * Use this to add background information (e.g., page views,
+		 * editorial notes) that will appear in the AI prompt.
+		 *
+		 * @param array<string, mixed> $context  Context data with strategy_id, strategy_hint, notes.
+		 * @param WP_Post              $post     The selected post.
+		 * @param array<string, mixed> $strategy The strategy used.
+		 */
+		return apply_filters( 'boswell_post_context', $context, $post, $strategy );
+	}
+}

--- a/tests/test-commenter-context.php
+++ b/tests/test-commenter-context.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Tests for Boswell_Commenter context and safety valve
+ *
+ * @package Boswell
+ */
+
+class Test_Boswell_Commenter_Context extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		delete_option( Boswell_Persona::OPTION_KEY );
+		remove_all_filters( 'boswell_should_comment' );
+		remove_all_filters( 'boswell_post_context' );
+	}
+
+	/**
+	 * Create a test persona.
+	 *
+	 * @return array{persona_id: string, user_id: int}
+	 */
+	private function create_test_persona(): array {
+		$user_id = self::factory()->user->create();
+		$id      = Boswell_Persona::save(
+			array(
+				'name'     => 'Test Persona',
+				'persona'  => 'A test persona.',
+				'user_id'  => $user_id,
+				'provider' => 'anthropic',
+			)
+		);
+		return array(
+			'persona_id' => $id,
+			'user_id'    => $user_id,
+		);
+	}
+
+	public function test_should_comment_filter_blocks_comment(): void {
+		$setup   = $this->create_test_persona();
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$filter_called = false;
+		add_filter(
+			'boswell_should_comment',
+			function ( $should, $post, $persona ) use ( &$filter_called ) {
+				$filter_called = true;
+				return false;
+			},
+			10,
+			3
+		);
+
+		$result = Boswell_Commenter::comment( $post_id, $setup['persona_id'] );
+
+		$this->assertTrue( $filter_called );
+		$this->assertWPError( $result );
+		$this->assertSame( 'boswell_comment_blocked', $result->get_error_code() );
+	}
+
+	public function test_should_comment_filter_receives_correct_args(): void {
+		$setup   = $this->create_test_persona();
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$received_post    = null;
+		$received_persona = null;
+		add_filter(
+			'boswell_should_comment',
+			function ( $should, $post, $persona ) use ( &$received_post, &$received_persona ) {
+				$received_post    = $post;
+				$received_persona = $persona;
+				return false; // Block to prevent AI call.
+			},
+			10,
+			3
+		);
+
+		Boswell_Commenter::comment( $post_id, $setup['persona_id'] );
+
+		$this->assertInstanceOf( WP_Post::class, $received_post );
+		$this->assertSame( $post_id, $received_post->ID );
+		$this->assertIsArray( $received_persona );
+		$this->assertSame( $setup['persona_id'], $received_persona['id'] );
+	}
+
+	public function test_should_comment_default_allows(): void {
+		$setup   = $this->create_test_persona();
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		// Without the filter returning false, comment() proceeds past the safety valve.
+		// It will fail at the AI client step (not installed in tests), but the error
+		// should NOT be 'boswell_comment_blocked'.
+		$result = Boswell_Commenter::comment( $post_id, $setup['persona_id'] );
+
+		$this->assertWPError( $result );
+		$this->assertNotSame( 'boswell_comment_blocked', $result->get_error_code() );
+	}
+}

--- a/tests/test-cron.php
+++ b/tests/test-cron.php
@@ -98,47 +98,6 @@ class Test_Boswell_Cron extends WP_UnitTestCase {
 		$this->assertFalse( wp_next_scheduled( Boswell_Cron::HOOK_NAME, array( $id2 ) ) );
 	}
 
-	public function test_select_post_returns_uncommented_post(): void {
-		$user_id = self::factory()->user->create();
-		$post_id = self::factory()->post->create( array( 'post_date' => gmdate( 'Y-m-d H:i:s' ) ) );
-		$persona = array( 'user_id' => $user_id );
-
-		$selected = Boswell_Cron::select_post( 0, $persona );
-		$this->assertSame( $post_id, $selected );
-	}
-
-	public function test_select_post_excludes_already_commented(): void {
-		$user_id = self::factory()->user->create();
-		$post_id = self::factory()->post->create( array( 'post_date' => gmdate( 'Y-m-d H:i:s' ) ) );
-
-		self::factory()->comment->create(
-			array(
-				'comment_post_ID' => $post_id,
-				'user_id'         => $user_id,
-			)
-		);
-
-		$persona  = array( 'user_id' => $user_id );
-		$selected = Boswell_Cron::select_post( 0, $persona );
-		$this->assertSame( 0, $selected );
-	}
-
-	public function test_select_post_respects_existing_selection(): void {
-		$persona = array( 'user_id' => 1 );
-		$this->assertSame( 999, Boswell_Cron::select_post( 999, $persona ) );
-	}
-
-	public function test_select_post_ignores_old_posts(): void {
-		$user_id = self::factory()->user->create();
-		self::factory()->post->create(
-			array( 'post_date' => gmdate( 'Y-m-d H:i:s', strtotime( '-120 days' ) ) )
-		);
-
-		$persona  = array( 'user_id' => $user_id );
-		$selected = Boswell_Cron::select_post( 0, $persona );
-		$this->assertSame( 0, $selected );
-	}
-
 	public function test_uninstall_clears_all_schedules(): void {
 		$id = $this->create_persona( array( 'cron_enabled' => true ) );
 		Boswell_Cron::uninstall();

--- a/tests/test-strategy-selector.php
+++ b/tests/test-strategy-selector.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Tests for Boswell_Strategy_Selector
+ *
+ * @package Boswell
+ */
+
+class Test_Boswell_Strategy_Selector extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		remove_all_filters( 'boswell_comment_strategies' );
+		remove_all_filters( 'boswell_select_post_args' );
+		remove_all_filters( 'boswell_post_context' );
+	}
+
+	// --- get_strategies() ---
+
+	public function test_default_strategies_contains_recent(): void {
+		$strategies = Boswell_Strategy_Selector::get_strategies();
+		$this->assertCount( 1, $strategies );
+		$this->assertSame( 'recent', $strategies[0]['id'] );
+		$this->assertArrayHasKey( 'query_args', $strategies[0] );
+		$this->assertArrayHasKey( 'hint', $strategies[0] );
+	}
+
+	public function test_strategies_filter_adds_custom(): void {
+		add_filter(
+			'boswell_comment_strategies',
+			function ( $s ) {
+				$s[] = array(
+					'id'         => 'custom',
+					'weight'     => 1,
+					'query_args' => array(),
+					'hint'       => 'Custom.',
+				);
+				return $s;
+			}
+		);
+
+		$strategies = Boswell_Strategy_Selector::get_strategies();
+		$this->assertCount( 2, $strategies );
+		$this->assertSame( 'custom', $strategies[1]['id'] );
+	}
+
+	// --- pick_weighted() ---
+
+	public function test_pick_weighted_single_strategy(): void {
+		$strategies = array(
+			array(
+				'id'     => 'only',
+				'weight' => 1,
+			),
+		);
+		$picked     = Boswell_Strategy_Selector::pick_weighted( $strategies );
+		$this->assertSame( 'only', $picked['id'] );
+	}
+
+	public function test_pick_weighted_respects_weights(): void {
+		$strategies = array(
+			array(
+				'id'     => 'heavy',
+				'weight' => 100,
+			),
+			array(
+				'id'     => 'light',
+				'weight' => 1,
+			),
+		);
+		$counts     = array(
+			'heavy' => 0,
+			'light' => 0,
+		);
+		for ( $i = 0; $i < 200; $i++ ) {
+			$picked = Boswell_Strategy_Selector::pick_weighted( $strategies );
+			++$counts[ $picked['id'] ];
+		}
+		$this->assertGreaterThan( 150, $counts['heavy'] );
+	}
+
+	// --- select() ---
+
+	public function test_select_returns_recent_post(): void {
+		$user_id = self::factory()->user->create();
+		$post_id = self::factory()->post->create( array( 'post_date' => gmdate( 'Y-m-d H:i:s' ) ) );
+		$persona = array( 'user_id' => $user_id );
+
+		$result = Boswell_Strategy_Selector::select( $persona );
+		$this->assertSame( $post_id, $result['post_id'] );
+		$this->assertSame( 'recent', $result['context']['strategy_id'] );
+	}
+
+	public function test_select_excludes_commented_posts(): void {
+		$user_id = self::factory()->user->create();
+		$post_id = self::factory()->post->create( array( 'post_date' => gmdate( 'Y-m-d H:i:s' ) ) );
+		self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'user_id'         => $user_id,
+			)
+		);
+		$persona = array( 'user_id' => $user_id );
+
+		$result = Boswell_Strategy_Selector::select( $persona );
+		$this->assertSame( 0, $result['post_id'] );
+	}
+
+	public function test_select_ignores_old_posts_with_default_strategy(): void {
+		$user_id = self::factory()->user->create();
+		self::factory()->post->create(
+			array( 'post_date' => gmdate( 'Y-m-d H:i:s', strtotime( '-120 days' ) ) )
+		);
+		$persona = array( 'user_id' => $user_id );
+
+		$result = Boswell_Strategy_Selector::select( $persona );
+		$this->assertSame( 0, $result['post_id'] );
+	}
+
+	public function test_select_returns_zero_when_no_strategies(): void {
+		add_filter( 'boswell_comment_strategies', '__return_empty_array' );
+
+		$persona = array( 'user_id' => 1 );
+		$result  = Boswell_Strategy_Selector::select( $persona );
+		$this->assertSame( 0, $result['post_id'] );
+		$this->assertEmpty( $result['context'] );
+	}
+
+	// --- boswell_select_post_args filter ---
+
+	public function test_select_post_args_filter_can_exclude_category(): void {
+		$user_id = self::factory()->user->create();
+		$cat_id  = self::factory()->category->create( array( 'slug' => 'no-ai' ) );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_date'     => gmdate( 'Y-m-d H:i:s' ),
+				'post_category' => array( $cat_id ),
+			)
+		);
+
+		add_filter(
+			'boswell_select_post_args',
+			function ( $args ) use ( $cat_id ) {
+				$args['category__not_in'] = array( $cat_id );
+				return $args;
+			},
+			10,
+			3
+		);
+
+		$persona = array( 'user_id' => $user_id );
+		$result  = Boswell_Strategy_Selector::select( $persona );
+		$this->assertSame( 0, $result['post_id'] );
+	}
+
+	// --- boswell_post_context filter ---
+
+	public function test_post_context_filter_adds_notes(): void {
+		$user_id = self::factory()->user->create();
+		$post_id = self::factory()->post->create( array( 'post_date' => gmdate( 'Y-m-d H:i:s' ) ) );
+
+		add_filter(
+			'boswell_post_context',
+			function ( $context ) {
+				$context['notes'][] = 'Test note';
+				return $context;
+			},
+			10,
+			3
+		);
+
+		$persona = array( 'user_id' => $user_id );
+		$result  = Boswell_Strategy_Selector::select( $persona );
+		$this->assertSame( $post_id, $result['post_id'] );
+		$this->assertContains( 'Test note', $result['context']['notes'] );
+	}
+
+	public function test_context_contains_strategy_hint(): void {
+		$user_id = self::factory()->user->create();
+		self::factory()->post->create( array( 'post_date' => gmdate( 'Y-m-d H:i:s' ) ) );
+		$persona = array( 'user_id' => $user_id );
+
+		$result = Boswell_Strategy_Selector::select( $persona );
+		$this->assertArrayHasKey( 'strategy_hint', $result['context'] );
+		$this->assertNotEmpty( $result['context']['strategy_hint'] );
+	}
+}


### PR DESCRIPTION
## Summary

Closes #8

- Replace raw SQL post selection with strategy-based `WP_Query` selection (`Boswell_Strategy_Selector`)
- Add 4 filter hooks for external customization: `boswell_comment_strategies`, `boswell_select_post_args`, `boswell_post_context`, `boswell_should_comment`
- Enrich AI prompt with post date, categories, and "Why This Post" context section
- Add `wp boswell strategies` CLI command and `--strategy` option to `wp boswell run`
- Remove deprecated `select_post()` method and `boswell_select_post` filter
- Add [Wiki documentation](https://github.com/hametuha/boswell/wiki) for strategy customization

## Test plan

- [ ] `npm test` — 58 tests pass (12 new strategy tests + 3 commenter context tests)
- [ ] `composer lint` — No PHPCS errors
- [ ] `wp boswell strategies` lists registered strategies with weight/probability
- [ ] `wp boswell run --persona=persona --strategy=recent` generates a comment using the specified strategy
- [ ] `boswell_should_comment` filter returning `false` blocks comment on all paths (cron, CLI, MCP, REST)

🤖 Generated with [Claude Code](https://claude.com/claude-code)