### PR TITLE
Remove redundant MCP Adapter install step from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,7 @@ Since WordPress 7.0, these extensions above will not be bundled.
 
 ### MCP Connection
 
-To connect Claude Desktop to your WordPress site:
-
-1. Install and activate the [MCP Adapter](https://github.com/WordPress/mcp-adapter) plugin.
-2. Add the MCP server to your Claude Desktop configuration:
+To connect Claude Desktop to your WordPress site, add the MCP server to your Claude Desktop configuration:
 
 ```json
 {


### PR DESCRIPTION
## Summary

- MCP Adapter is bundled via Composer (`vendor/`), so users don't need to install it separately
- Remove the numbered step "Install and activate the MCP Adapter plugin" from MCP Connection section

🤖 Generated with [Claude Code](https://claude.com/claude-code)