### PR TITLE
Target WordPress 7.0 core AI Client, drop bundled deps (v2.0.0)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -6,10 +6,13 @@
 .husky
 .mcp.json
 .wp-env.json
+composer.json
+composer.lock
 node_modules
 package.json
 package-lock.json
 phpcs.ruleset.xml
 phpunit.xml.dist
 tests
+vendor
 wp

--- a/README.md
+++ b/README.md
@@ -57,8 +57,13 @@ Each provider plugin registers itself with the core AI Client registry on activa
 1. Download the latest release zip from [GitHub Releases](https://github.com/hametuha/boswell/releases).
 2. Upload the zip file via **Plugins > Add New > Upload Plugin** in WordPress admin.
 3. Activate the plugin.
-4. Go to **Settings > Boswell** to configure personas.
-5. Set up your AI provider API key (e.g., `ANTHROPIC_API_KEY` constant or environment variable).
+4. Install at least one AI provider plugin (e.g. [AI Provider for Anthropic](https://wordpress.org/plugins/ai-provider-for-anthropic/)) and the [MCP Adapter](https://github.com/WordPress/mcp-adapter) plugin.
+5. Go to **Settings > Boswell** to configure personas.
+6. Set up your AI provider API key (e.g., `ANTHROPIC_API_KEY` constant or environment variable).
+
+### Upgrading from 0.1.0
+
+Boswell 0.1.0 bundled the AI Client, AI Provider for Anthropic, and MCP Adapter inside `vendor/`. From the next release these are no longer bundled — they must be installed separately (the AI Client is now part of WordPress 7.0 core). **Before upgrading on a site that has 0.1.0 installed, delete the existing `wp-content/plugins/boswell/` directory** to ensure the old `vendor/` packages don't shadow the new core/plugin equivalents and produce class-redeclaration fatals.
 
 ### MCP Connection
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Tags: ai, comments, persona, mcp, content  
 Contributors: hametuha, Takahashi_Fumiki  
-Tested Up to: 6.9  
+Tested Up to: 7.0  
 Stable Tag: 0.1.0  
-Requires at least: 6.9  
+Requires at least: 7.0  
 Requires PHP: 8.1  
 License: GPLv3 or later  
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -26,7 +26,7 @@ Boswell enriches your WordPress blog with AI-powered personas that can comment o
 
 ### How It Works
 
-Boswell registers its capabilities through the [WordPress Abilities API](https://make.wordpress.org/core/tag/abilities-api/) (available in WordPress 6.9+). The [MCP Adapter](https://github.com/WordPress/mcp-adapter) plugin exposes these abilities as MCP tools, resources, and prompts.
+Boswell registers its capabilities through the [WordPress Abilities API](https://make.wordpress.org/core/tag/abilities-api/) (in core since WordPress 6.9). The [MCP Adapter](https://github.com/WordPress/mcp-adapter) plugin exposes these abilities as MCP tools, resources, and prompts.
 
 ```
 Claude Desktop ←MCP→ WordPress (MCP Adapter)
@@ -44,13 +44,13 @@ Claude Desktop ←MCP→ WordPress (MCP Adapter)
 
 ### AI Providers
 
-Boswell uses [wp-ai-client](https://github.com/WordPress/wp-ai-client) for AI text generation. You need at least one AI provider plugin installed:
+Boswell uses the WordPress AI Client (`wp_ai_client_prompt()`), which has been part of core since WordPress 7.0. You need at least one AI provider plugin installed:
 
-- [AI Provider for Anthropic](https://github.com/WordPress/ai-provider-for-anthropic) (bundled)
-- [AI Provider for OpenAI](https://github.com/WordPress/openai-ai-provider) (optional)
-- [AI Provider for Google](https://github.com/WordPress/google-ai-provider) (optional)
+- [AI Provider for Anthropic](https://github.com/WordPress/ai-provider-for-anthropic)
+- [AI Provider for OpenAI](https://github.com/WordPress/openai-ai-provider)
+- [AI Provider for Google](https://github.com/WordPress/google-ai-provider)
 
-Since WordPress 7.0, these extensions above will not be bundled.
+Each provider plugin registers itself with the core AI Client registry on activation — no extra configuration in Boswell is required.
 
 ## Installation
 
@@ -86,11 +86,11 @@ To connect Claude Desktop to your WordPress site:
 
 ### What WordPress version is required?
 
-WordPress 6.9 or later is required for the Abilities API.
+WordPress 7.0 or later. Boswell relies on the AI Client that shipped with WordPress 7.0 core. (The Abilities API has been part of core since 6.9.)
 
 ### Can I use multiple AI providers?
 
-Yes. Install additional AI provider plugins (OpenAI, Google) alongside the bundled Anthropic provider. WordPress will use whichever is configured.
+Yes. Install the AI provider plugins you want (Anthropic, OpenAI, Google) — each one self-registers with the core AI Client. Configure each persona to point at the provider you want to use.
 
 ### How do I create a persona?
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Each provider plugin registers itself with the core AI Client registry on activa
 5. Go to **Settings > Boswell** to configure personas.
 6. Set up your AI provider API key (e.g., `ANTHROPIC_API_KEY` constant or environment variable).
 
-### Upgrading from 0.1.0
+### Upgrading from 1.x
 
-Boswell 0.1.0 bundled the AI Client, AI Provider for Anthropic, and MCP Adapter inside `vendor/`. From the next release these are no longer bundled — they must be installed separately (the AI Client is now part of WordPress 7.0 core). **Before upgrading on a site that has 0.1.0 installed, delete the existing `wp-content/plugins/boswell/` directory** to ensure the old `vendor/` packages don't shadow the new core/plugin equivalents and produce class-redeclaration fatals.
+Boswell 1.x bundled the AI Client, AI Provider for Anthropic, and MCP Adapter inside `vendor/`. From 2.0.0 these are no longer bundled — they must be installed as standalone plugins (the AI Client is now part of WordPress 7.0 core). **Before upgrading a site that has 1.x installed, delete the existing `wp-content/plugins/boswell/` directory** so the old `vendor/` packages don't shadow the new core/plugin equivalents and trigger class-redeclaration fatals.
 
 ### MCP Connection
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Tags: ai, comments, persona, mcp, content  
 Contributors: hametuha, Takahashi_Fumiki  
 Tested Up to: 7.0  
-Stable Tag: 0.1.0  
+Stable Tag: 2.0.0  
 Requires at least: 7.0  
 Requires PHP: 8.1  
 License: GPLv3 or later  
@@ -109,11 +109,46 @@ Yes. Each persona can have a cron schedule (e.g., daily). Boswell will automatic
 
 See the [Wiki](https://github.com/hametuha/boswell/wiki) for details on adding custom strategies, adjusting query parameters, enriching post context, and blocking comments on specific posts or categories.
 
+## Upgrade Notice
+
+### 2.0.0
+
+Requires WordPress 7.0. Before upgrading from 1.x, **delete the existing `wp-content/plugins/boswell/` directory** so the bundled `vendor/` packages don't shadow the standalone AI Provider and MCP Adapter plugins. Install AI Provider for Anthropic and MCP Adapter separately.
+
 ## Changelog
 
-### 0.1.0
+### 2.0.0
 
-- Initial release.
+- **Breaking:** Requires WordPress 7.0 and PHP 8.1.
+- Use the core AI Client (`wp_ai_client_prompt()`) introduced in WordPress 7.0 instead of the bundled `wp-ai-client` SDK.
+- No longer bundles `wp-ai-client`, `ai-provider-for-anthropic`, or `mcp-adapter` — install them as standalone plugins.
+- Update MCP ability metadata for MCP Adapter v0.5.0 (`uri` and `annotations` moved under the `mcp` key).
+- Release zip no longer ships `vendor/`, `composer.json`, or `composer.lock`.
+
+### 1.1.0
+
+- Add strategy-based post selection and comment safety valve.
+
+### 1.0.4
+
+- Fix deploy workflow: upload zip to existing release.
+
+### 1.0.3
+
+- Fix deploy clean step failing on non-existent files.
+
+### 1.0.2
+
+- Add version resolver to release-drafter.
+- Add README.md for WordPress readme.txt.
+
+### 1.0.1
+
+- Add deploy workflow with zip release on tag push.
+
+### 1.0.0
+
+- Initial release. AI persona management, shared memory, automated commenting via WordPress cron, MCP integration via the WordPress Abilities API, post CRUD tools, and WP-CLI commands.
 - AI persona management with admin UI.
 - Shared memory system with section-based Markdown storage.
 - Automated commenting via WordPress cron.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Tags: ai, comments, persona, mcp, content  
 Contributors: hametuha, Takahashi_Fumiki  
 Tested Up to: 7.0  
-Stable Tag: 2.0.0  
+Stable Tag: nightly  
 Requires at least: 7.0  
 Requires PHP: 8.1  
 License: GPLv3 or later  

--- a/boswell.php
+++ b/boswell.php
@@ -3,7 +3,7 @@
  * Plugin Name: Boswell
  * Plugin URI:  https://github.com/hametuha/boswell
  * Description: Enrich your WordPress blog contents with AI-powered assistant.
- * Version:     0.1.0
+ * Version:     2.0.0
  * Requires at least: 7.0
  * Requires PHP: 8.1
  * Author:      Fumiki Takahashi

--- a/boswell.php
+++ b/boswell.php
@@ -3,7 +3,7 @@
  * Plugin Name: Boswell
  * Plugin URI:  https://github.com/hametuha/boswell
  * Description: Enrich your WordPress blog contents with AI-powered assistant.
- * Version:     2.0.0
+ * Version:     nightly
  * Requires at least: 7.0
  * Requires PHP: 8.1
  * Author:      Fumiki Takahashi

--- a/boswell.php
+++ b/boswell.php
@@ -4,7 +4,7 @@
  * Plugin URI:  https://github.com/hametuha/boswell
  * Description: Enrich your WordPress blog contents with AI-powered assistant.
  * Version:     0.1.0
- * Requires at least: 6.9
+ * Requires at least: 7.0
  * Requires PHP: 8.1
  * Author:      Fumiki Takahashi
  * Author URI:  https://takahashifumiki.com
@@ -17,11 +17,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-// Composer autoloader (wp-ai-client, providers, etc.).
-if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
-	require_once __DIR__ . '/vendor/autoload.php';
-}
-
 // Load classes.
 require_once __DIR__ . '/includes/class-memory.php';
 require_once __DIR__ . '/includes/class-persona.php';
@@ -32,33 +27,6 @@ require_once __DIR__ . '/includes/class-cron.php';
 require_once __DIR__ . '/includes/class-rest-controller.php';
 require_once __DIR__ . '/includes/class-abilities.php';
 require_once __DIR__ . '/includes/class-cli.php';
-
-// Register AI providers and initialize wp-ai-client (will be unnecessary after WordPress 7.0).
-if ( class_exists( 'WordPress\AI_Client\AI_Client' ) ) {
-	add_action(
-		'init',
-		function () {
-			// Set up HTTP discovery first so providers can create their HTTP transporter.
-			WordPress\AI_Client\HTTP\WP_AI_Client_Discovery_Strategy::init();
-
-			// Register available providers.
-			$registry  = WordPress\AiClient\AiClient::defaultRegistry();
-			$providers = array(
-				'WordPress\AnthropicAiProvider\Provider\AnthropicProvider',
-				'WordPress\OpenAiAiProvider\Provider\OpenAiProvider',
-				'WordPress\GoogleAiProvider\Provider\GoogleProvider',
-			);
-			foreach ( $providers as $provider ) {
-				if ( class_exists( $provider ) ) {
-					$registry->registerProvider( $provider );
-				}
-			}
-
-			// Initialize wp-ai-client.
-			WordPress\AI_Client\AI_Client::init();
-		}
-	);
-}
 
 // MCP adapter (exposes Boswell abilities as MCP tools/resources/prompts).
 if ( class_exists( 'WP\MCP\Plugin' ) ) {

--- a/composer.json
+++ b/composer.json
@@ -3,23 +3,17 @@
 	"description": "Enrich your WordPress blog contents with AI-powered assistant.",
 	"type": "wordpress-plugin",
 	"license": "GPL-3.0-or-later",
-	"repositories": [
-		{ "type": "vcs", "url": "https://github.com/WordPress/wp-ai-client" },
-		{ "type": "vcs", "url": "https://github.com/WordPress/ai-provider-for-anthropic" },
-		{ "type": "vcs", "url": "https://github.com/WordPress/mcp-adapter" }
-	],
 	"require": {
-		"php": ">=8.1",
-		"wordpress/wp-ai-client": "^0.3.0",
-		"wordpress/ai-provider-for-anthropic": "^1.0",
-		"wordpress/mcp-adapter": "^0.4.1"
+		"php": ">=8.1"
 	},
 	"suggest": {
-		"wordpress/openai-ai-provider": "AI Provider for OpenAI (GPT). Install as WP plugin or via Composer.",
-		"wordpress/google-ai-provider": "AI Provider for Google (Gemini). Install as WP plugin or via Composer."
+		"wordpress/mcp-adapter": "MCP Adapter plugin — required to expose Boswell abilities as MCP tools/resources/prompts.",
+		"wordpress/ai-provider-for-anthropic": "AI Provider for Anthropic (Claude). Install as a WordPress plugin.",
+		"wordpress/openai-ai-provider": "AI Provider for OpenAI (GPT). Install as a WordPress plugin.",
+		"wordpress/google-ai-provider": "AI Provider for Google (Gemini). Install as a WordPress plugin."
 	},
 	"require-dev": {
-		"johnpbloch/wordpress": "6.9",
+		"johnpbloch/wordpress": "^7.0",
 		"wp-coding-standards/wpcs": "^3.0",
 		"phpunit/phpunit": "^9.0",
 		"yoast/phpunit-polyfills": "^4.0"

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -176,14 +176,14 @@ class Boswell_Abilities {
 					return current_user_can( 'edit_posts' );
 				},
 				'meta'                => array(
-					'uri'         => 'boswell://context',
-					'annotations' => array(
-						'audience' => array( 'user', 'assistant' ),
-						'priority' => 0.9,
-					),
-					'mcp'         => array(
-						'public' => true,
-						'type'   => 'resource',
+					'mcp' => array(
+						'public'      => true,
+						'type'        => 'resource',
+						'uri'         => 'boswell://context',
+						'annotations' => array(
+							'audience' => array( 'user', 'assistant' ),
+							'priority' => 0.9,
+						),
 					),
 				),
 			)
@@ -381,25 +381,25 @@ class Boswell_Abilities {
 					return current_user_can( 'edit_posts' );
 				},
 				'meta'                => array(
-					'arguments'   => array(
-						array(
-							'name'        => 'persona',
-							'description' => __( 'Persona ID (uses first persona if omitted).', 'boswell' ),
-							'required'    => false,
+					'mcp' => array(
+						'public'      => true,
+						'type'        => 'prompt',
+						'arguments'   => array(
+							array(
+								'name'        => 'persona',
+								'description' => __( 'Persona ID (uses first persona if omitted).', 'boswell' ),
+								'required'    => false,
+							),
+							array(
+								'name'        => 'topic',
+								'description' => __( 'Topic or theme for the post.', 'boswell' ),
+								'required'    => false,
+							),
 						),
-						array(
-							'name'        => 'topic',
-							'description' => __( 'Topic or theme for the post.', 'boswell' ),
-							'required'    => false,
+						'annotations' => array(
+							'audience' => array( 'user', 'assistant' ),
+							'priority' => 0.9,
 						),
-					),
-					'annotations' => array(
-						'audience' => array( 'user', 'assistant' ),
-						'priority' => 0.9,
-					),
-					'mcp'         => array(
-						'public' => true,
-						'type'   => 'prompt',
 					),
 				),
 			)

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -258,8 +258,8 @@ class Boswell_CLI extends WP_CLI_Command {
 			WP_CLI::error( $persona->get_error_message() );
 		}
 
-		if ( ! class_exists( 'WordPress\AI_Client\AI_Client' ) ) {
-			WP_CLI::error( 'wp-ai-client is not available.' );
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			WP_CLI::error( 'WordPress AI Client (WP 7.0+) is not available.' );
 		}
 
 		$memory = Boswell_Memory::get();
@@ -268,14 +268,13 @@ class Boswell_CLI extends WP_CLI_Command {
 			. "\n\n---\n\nBriefly report what you have been up to recently, in your own voice. "
 			. 'Be conversational and concise (a few sentences).';
 
-		try {
-			$report = WordPress\AI_Client\AI_Client::prompt( $prompt )
-				->using_provider( $persona['provider'] )
-				->using_system_instruction( $system )
-				->using_max_tokens( 500 )
-				->generate_text();
-		} catch ( \Exception $e ) {
-			WP_CLI::error( $e->getMessage() );
+		$report = wp_ai_client_prompt( $prompt )
+			->using_provider( $persona['provider'] )
+			->using_system_instruction( $system )
+			->using_max_tokens( 500 )
+			->generate_text();
+		if ( is_wp_error( $report ) ) {
+			WP_CLI::error( $report->get_error_message() );
 		}
 
 		WP_CLI::log( trim( $report ) );

--- a/includes/class-commenter.php
+++ b/includes/class-commenter.php
@@ -22,8 +22,8 @@ class Boswell_Commenter {
 	 * @return WP_Comment|WP_Error The comment object on success, WP_Error on failure.
 	 */
 	public static function comment( int $post_id, string $persona_id, int $parent_id = 0, array $context = array() ) {
-		if ( ! class_exists( 'WordPress\AI_Client\AI_Client' ) ) {
-			return new WP_Error( 'boswell_ai_client_missing', __( 'wp-ai-client is not available.', 'boswell' ) );
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			return new WP_Error( 'boswell_ai_client_missing', __( 'WordPress AI Client (WP 7.0+) is not available.', 'boswell' ) );
 		}
 
 		// 1. Resolve persona.
@@ -96,14 +96,13 @@ class Boswell_Commenter {
 		$prompt = self::build_prompt( $post, $parent, $context );
 
 		// 9. Generate comment text via AI.
-		try {
-			$comment_text = WordPress\AI_Client\AI_Client::prompt( $prompt )
-				->using_provider( $persona['provider'] )
-				->using_system_instruction( $system )
-				->using_max_tokens( 1500 )
-				->generate_text();
-		} catch ( \Exception $e ) {
-			return new WP_Error( 'boswell_generation_failed', $e->getMessage() );
+		$comment_text = wp_ai_client_prompt( $prompt )
+			->using_provider( $persona['provider'] )
+			->using_system_instruction( $system )
+			->using_max_tokens( 1500 )
+			->generate_text();
+		if ( is_wp_error( $comment_text ) ) {
+			return new WP_Error( 'boswell_generation_failed', $comment_text->get_error_message() );
 		}
 
 		$comment_text = trim( $comment_text );

--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -233,10 +233,10 @@ class Boswell_REST_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function ping( WP_REST_Request $request ) {
-		if ( ! class_exists( 'WordPress\AI_Client\AI_Client' ) ) {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
 			return new WP_Error(
 				'boswell_ai_client_missing',
-				__( 'wp-ai-client is not available.', 'boswell' ),
+				__( 'WordPress AI Client (WP 7.0+) is not available.', 'boswell' ),
 				array( 'status' => 500 )
 			);
 		}
@@ -251,16 +251,15 @@ class Boswell_REST_Controller extends WP_REST_Controller {
 			);
 		}
 
-		try {
-			$text = WordPress\AI_Client\AI_Client::prompt( 'Introduce yourself in one sentence.' )
-				->using_provider( $persona['provider'] )
-				->using_system_instruction( $persona['persona'] )
-				->using_max_tokens( 200 )
-				->generate_text();
-		} catch ( \Exception $e ) {
+		$text = wp_ai_client_prompt( 'Introduce yourself in one sentence.' )
+			->using_provider( $persona['provider'] )
+			->using_system_instruction( $persona['persona'] )
+			->using_max_tokens( 200 )
+			->generate_text();
+		if ( is_wp_error( $text ) ) {
 			return new WP_Error(
 				'boswell_ping_failed',
-				$e->getMessage(),
+				$text->get_error_message(),
 				array( 'status' => 502 )
 			);
 		}


### PR DESCRIPTION
## Summary

Targets WordPress 7.0 — uses the AI Client that landed in core (`wp_ai_client_prompt()`) instead of the SDK that 1.x bundled in `vendor/`. AI Provider for Anthropic and MCP Adapter become external plugins users install themselves.

- Switch AI calls in `class-commenter`, `class-cli`, `class-rest-controller` to `wp_ai_client_prompt()`; replace `try/catch` with `is_wp_error()` since the core builder returns `WP_Error`.
- Remove `vendor/autoload.php` require and the manual provider registration block from `boswell.php`.
- Drop `wp-ai-client`, `ai-provider-for-anthropic`, `mcp-adapter` from `composer require`; move them to `suggest` and bump `johnpbloch/wordpress` dev dep to `^7.0`.
- Move ability meta keys `uri` and `annotations` under `mcp.*` to silence MCP Adapter v0.5.0 deprecations.
- Add `vendor`, `composer.json`, `composer.lock` to `.distignore` so the release zip stops shipping conflicting copies of the now-standalone plugins.
- Bump `Requires at least` to 7.0; replace in-source `Version` and `Stable Tag` with `nightly` (deploy.yml overwrites them from the git tag at build time anyway).
- Back-fill 1.0.0–1.1.0 entries into the README Changelog and add 2.0.0 entry + Upgrade Notice.

## Why 2.0.0 not 1.2.0

- WordPress requirement moves 6.9 → 7.0.
- Standalone install steps change: users must install AI Provider plugins and MCP Adapter separately.
- Existing 1.x installs must delete `wp-content/plugins/boswell/` before upgrading to avoid class-redeclaration fatals from the old bundled `vendor/`.

## Test plan

- [x] WP 7.0 local environment, with `ai-provider-for-anthropic` (wp.org) and `mcp-adapter` v0.5.0 (GitHub release) activated alongside this branch
- [x] `wp boswell personas` lists the configured persona without warnings
- [x] All 10 boswell abilities register; MCP Adapter v0.5.0 emits no deprecation notices
- [x] `POST /wp-json/mcp/mcp-adapter-default-server` returns 200 with valid initialize response when authenticated via Application Password
- [x] Claude Desktop (via `@automattic/mcp-wordpress-remote`) creates a draft post via `boswell/create-post`
- [ ] Production rollout: deactivate → upgrade WP → delete old plugin dir → install companion plugins → upload 2.0.0 zip → reactivate