### PR TITLE
Replace commentary_log truncation with AI-generated summary (#13)

### DIFF
--- a/includes/class-commenter.php
+++ b/includes/class-commenter.php
@@ -13,6 +13,19 @@
 class Boswell_Commenter {
 
 	/**
+	 * Separator the AI uses to delimit the comment body from the memory summary line.
+	 *
+	 * HTML comments are chosen so the marker remains invisible if it ever leaks through
+	 * to the rendered output, and so the AI treats it as structural rather than narrative.
+	 */
+	const MEMORY_SEPARATOR = '<!--BOSWELL_MEMORY-->';
+
+	/**
+	 * Maximum number of characters allowed in a memory summary line.
+	 */
+	const MEMORY_SUMMARY_MAX_CHARS = 80;
+
+	/**
 	 * Generate and post a comment on a given post as a given persona.
 	 *
 	 * @param int                  $post_id    The post ID to comment on.
@@ -96,16 +109,17 @@ class Boswell_Commenter {
 		$prompt = self::build_prompt( $post, $parent, $context );
 
 		// 9. Generate comment text via AI.
-		$comment_text = wp_ai_client_prompt( $prompt )
+		$generated = wp_ai_client_prompt( $prompt )
 			->using_provider( $persona['provider'] )
 			->using_system_instruction( $system )
 			->using_max_tokens( 1500 )
 			->generate_text();
-		if ( is_wp_error( $comment_text ) ) {
-			return new WP_Error( 'boswell_generation_failed', $comment_text->get_error_message() );
+		if ( is_wp_error( $generated ) ) {
+			return new WP_Error( 'boswell_generation_failed', $generated->get_error_message() );
 		}
 
-		$comment_text = trim( $comment_text );
+		[ $comment_text, $memory_summary ] = self::parse_generated_output( $generated );
+
 		if ( empty( $comment_text ) ) {
 			return new WP_Error( 'boswell_empty_comment', __( 'AI returned an empty comment.', 'boswell' ) );
 		}
@@ -130,6 +144,12 @@ class Boswell_Commenter {
 		}
 
 		// 11. Update memory.
+		// Prefer the AI-generated single-line summary; fall back to the legacy
+		// truncation when the AI omitted the separator or returned an empty summary.
+		$summary = '' !== $memory_summary
+			? $memory_summary
+			: self::fallback_summary( $comment_text );
+
 		$title = $post->post_title;
 		if ( $parent ) {
 			Boswell_Memory::append_entry(
@@ -143,7 +163,7 @@ class Boswell_Commenter {
 					$post->ID,
 					$title,
 					$parent->comment_author,
-					mb_strimwidth( $comment_text, 0, 100, '...' )
+					$summary
 				)
 			);
 		} else {
@@ -157,7 +177,7 @@ class Boswell_Commenter {
 					'Post #%d "%s": %s',
 					$post->ID,
 					$title,
-					mb_strimwidth( $comment_text, 0, 100, '...' )
+					$summary
 				)
 			);
 		}
@@ -185,9 +205,66 @@ class Boswell_Commenter {
 			. "- Reference your memory if relevant, but don't force it.\n"
 			. "- Keep the comment concise (1-3 paragraphs).\n"
 			. "- If you are replying to someone, address their points directly.\n"
-			. '- Do NOT include any metadata, headers, or labels — just the comment text.';
+			. '- Do NOT include any metadata, headers, or labels in the comment body.';
+
+		$parts[] = "---\n\n## Output Format\n\n"
+			. "After the comment, output the literal separator on its own line, then a one-line\n"
+			. "summary that will be appended to your memory log. Use this exact structure:\n\n"
+			. "    <comment body, in the persona's voice>\n"
+			. '    ' . self::MEMORY_SEPARATOR . "\n"
+			. "    <memory line>\n\n"
+			. "Rules for the memory line:\n"
+			. sprintf( "- One line, no line breaks, at most %d characters.\n", self::MEMORY_SUMMARY_MAX_CHARS )
+			. "- Neutral ledger tone (NOT in the persona's voice — think \"journal entry\").\n"
+			. "- Capture the post's topic and your stance toward it.\n"
+			. "- Exclude greetings, opening phrases, and other formulaic words.\n"
+			. '- Write in the same language as the comment body.';
 
 		return implode( "\n\n", $parts );
+	}
+
+	/**
+	 * Split AI-generated output into the comment body and the memory summary line.
+	 *
+	 * If the separator is missing or the summary is blank, the second element is
+	 * returned as an empty string so the caller can fall back to legacy truncation.
+	 *
+	 * @param string $generated Raw text returned by the AI.
+	 * @return array{0: string, 1: string} [ comment_body, memory_summary ]
+	 */
+	private static function parse_generated_output( string $generated ): array {
+		$pos = strpos( $generated, self::MEMORY_SEPARATOR );
+		if ( false === $pos ) {
+			return array( trim( $generated ), '' );
+		}
+
+		$body    = trim( substr( $generated, 0, $pos ) );
+		$summary = trim( substr( $generated, $pos + strlen( self::MEMORY_SEPARATOR ) ) );
+
+		// Collapse any whitespace (including newlines) into single spaces so the
+		// summary always stays on a single Markdown list line.
+		$summary = trim( preg_replace( '/\s+/u', ' ', $summary ) );
+
+		if ( mb_strlen( $summary ) > self::MEMORY_SUMMARY_MAX_CHARS ) {
+			$summary = mb_substr( $summary, 0, self::MEMORY_SUMMARY_MAX_CHARS - 1 ) . '…';
+		}
+
+		return array( $body, $summary );
+	}
+
+	/**
+	 * Build a fallback memory summary from the raw comment body.
+	 *
+	 * Used when the AI omitted the separator or returned an empty summary. Collapses
+	 * whitespace before truncating so multi-paragraph comments do not break the
+	 * Markdown list in commentary_log.
+	 *
+	 * @param string $comment_text The comment body the AI produced.
+	 * @return string
+	 */
+	private static function fallback_summary( string $comment_text ): string {
+		$flat = trim( preg_replace( '/\s+/u', ' ', $comment_text ) );
+		return mb_strimwidth( $flat, 0, 100, '...' );
 	}
 
 	/**

--- a/includes/class-memory.php
+++ b/includes/class-memory.php
@@ -96,6 +96,15 @@ class Boswell_Memory {
 			return false;
 		}
 
+		// Collapse any whitespace (including newlines) into single spaces so the entry
+		// stays on a single Markdown list item. Without this, a multi-paragraph entry
+		// would break the list and subsequent lines would be silently dropped by
+		// extract_entries() on the next append.
+		$entry = trim( preg_replace( '/\s+/u', ' ', $entry ) );
+		if ( '' === $entry ) {
+			return false;
+		}
+
 		$memory  = self::get();
 		$heading = self::SECTIONS[ $section ];
 		$parsed  = self::parse_sections( $memory );


### PR DESCRIPTION
## Summary

Closes #13.

`commentary_log` entries have been a string of identical opening-greeting fragments because two bugs reinforced each other:

- `mb_strimwidth` did not collapse newlines, so multi-paragraph AI output broke the Markdown list at the first blank line and the rest fell out of the entry.
- `Boswell_Memory::extract_entries()` only keeps lines that start with `- `, so on the next `append_entry()` call the fallen-out lines were silently dropped — leaving only the persona's salutation.

## Approach

Ask the AI to emit the comment body and a one-line summary in a single call, separated by the literal `<!--BOSWELL_MEMORY-->`:

```
<comment body, in the persona's voice>
<!--BOSWELL_MEMORY-->
<memory line — neutral ledger tone, ≤80 chars, single line>
```

`Boswell_Commenter::parse_generated_output()` splits the response; the body is inserted as the comment, the summary goes into `commentary_log`. If the separator is missing or the summary is empty, fall back to the legacy `mb_strimwidth` path with whitespace collapsed first (so multi-paragraph comments can no longer corrupt the list).

A defensive whitespace-collapse + empty-entry rejection in `Boswell_Memory::append_entry()` makes the same guarantee hold for every caller (CLI, REST, MCP, future paths).

## Migration

Existing `commentary_log` entries are all formulaic openings with zero information value. Recommended cleanup after deploy:

```bash
wp boswell memory --section=commentary_log   # confirm current state
# Use the boswell/add-memory ability or the REST PUT /memory endpoint to
# replace the section with an empty body.
```

## Test plan

- [ ] AI returns body + separator + summary → comment posts, summary lands in commentary_log on a single line
- [ ] AI omits separator → fallback summary used; multi-paragraph body collapses to one line
- [ ] AI returns empty summary line → fallback used
- [ ] Summary with embedded newlines → collapsed to spaces, truncated to 80 chars
- [ ] Existing recent_activities / notes sections still append correctly (defensive change is general)
- [ ] phpcs / phpunit (CI)