### PR TITLE
Document 2.0.1 changelog (shared-memory quality)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,19 @@ See the [Wiki](https://github.com/hametuha/boswell/wiki) for details on adding c
 
 ## Upgrade Notice
 
+### 2.0.1
+
+Improves the quality of Boswell's shared memory. When upgrading from 1.x, the same step as 2.0.0 still applies: **delete the existing `wp-content/plugins/boswell/` directory** before installing so the old bundled `vendor/` cannot shadow the standalone AI Provider and MCP Adapter plugins.
+
 ### 2.0.0
 
 Requires WordPress 7.0. Before upgrading from 1.x, **delete the existing `wp-content/plugins/boswell/` directory** so the bundled `vendor/` packages don't shadow the standalone AI Provider and MCP Adapter plugins. Install AI Provider for Anthropic and MCP Adapter separately.
 
 ## Changelog
+
+### 2.0.1
+
+- Improve shared-memory quality: the commentary log now stores a concise, AI-generated summary of each comment instead of a truncated snippet. Entries stay informative and no longer collapse into repeated greetings, and multi-paragraph comments can no longer break the memory list.
 
 ### 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -108,10 +108,6 @@ See the [Wiki](https://github.com/hametuha/boswell/wiki) for details on adding c
 
 ## Upgrade Notice
 
-### 2.0.1
-
-Improves the quality of Boswell's shared memory. When upgrading from 1.x, the same step as 2.0.0 still applies: **delete the existing `wp-content/plugins/boswell/` directory** before installing so the old bundled `vendor/` cannot shadow the standalone AI Provider and MCP Adapter plugins.
-
 ### 2.0.0
 
 Requires WordPress 7.0. Before upgrading from 1.x, **delete the existing `wp-content/plugins/boswell/` directory** so the bundled `vendor/` packages don't shadow the standalone AI Provider and MCP Adapter plugins. Install AI Provider for Anthropic and MCP Adapter separately.


### PR DESCRIPTION
Changelog + upgrade notice for the 2.0.1 release, ahead of tagging.

Highlights the user-facing change — the commentary log now stores an AI-generated summary instead of a truncated snippet (#13 / #14), so memory entries stay informative instead of collapsing into repeated greetings. Dev-only tooling (PHPStan, Playground) is intentionally omitted from the changelog.

Merge this before creating the 2.0.1 release so the tagged commit (and the generated readme.txt) carries the changelog.