### PR TITLE
Fix: .distignore の wp を行頭アンカーし配下の誤除外を防ぐ

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -19,4 +19,4 @@ phpstan.neon
 phpunit.xml.dist
 tests
 vendor
-wp
+/wp


### PR DESCRIPTION
## 背景

`.distignore` は `.gitignore` と同様に、行頭スラッシュなしのパターンは全階層に再帰的にマッチします。

そのため `wp` という行はルート直下の `wp/` だけでなく、将来的に `vendor/**/wp` のような配下のパスまで意図せず除外してしまう「時限爆弾」になり得ます。リリース用ZIPから本来含めるべきファイルが欠落するリスクがあります。

ルート直下のみを除外したい場合は、行頭にスラッシュ（`/`）を付けてアンカーする必要があります。

## 変更内容

- `.distignore` の `wp` を `/wp` に変更し、ルート直下のみにマッチするようアンカーしました。

```diff
-wp
+/wp
```