### PR TITLE
Fix: automated commenting stops after reactivation/upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Requires WordPress 7.0. Before upgrading from 1.x, **delete the existing `wp-con
 
 ## Changelog
 
+### 2.0.2
+
+- Fix automated commenting silently stopping after a plugin reactivation or upgrade. The deactivation hook clears all scheduled cron events, but reactivation never restored them (only saving a persona did), so the 1.x → 2.0 directory-delete migration left commenting dormant. Schedules are now reconciled on activation and self-heal on every admin request.
+
 ### 2.0.1
 
 - Improve shared-memory quality: the commentary log now stores a concise, AI-generated summary of each comment instead of a truncated snippet. Entries stay informative and no longer collapse into repeated greetings, and multi-paragraph comments can no longer break the memory list.

--- a/boswell.php
+++ b/boswell.php
@@ -68,6 +68,9 @@ register_activation_hook(
 			update_option( Boswell_Memory::UPDATED_AT_KEY, gmdate( 'c' ), false );
 		}
 		Boswell_Persona::migrate();
+		// Re-establish cron schedules so automated commenting resumes after a
+		// reactivation or upgrade (the deactivation hook clears all events).
+		Boswell_Cron::sync_schedules();
 	}
 );
 

--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -24,6 +24,43 @@ class Boswell_Cron {
 	 */
 	public static function init(): void {
 		add_action( self::HOOK_NAME, array( __CLASS__, 'handle' ) );
+		// Self-heal: re-establish missing schedules on admin requests. The
+		// deactivation hook wipes all events, and reactivation/upgrade (e.g. the
+		// 1.x -> 2.0 directory-delete migration) does not re-save personas, so
+		// without this the automated commenting would stay silent forever.
+		add_action( 'admin_init', array( __CLASS__, 'sync_schedules' ) );
+	}
+
+	/**
+	 * Reconcile cron events with persona settings.
+	 *
+	 * Idempotent: schedules an event for every cron-enabled persona that is
+	 * missing one, and clears events for personas that have cron disabled.
+	 * Safe to call on activation and on every admin request, so automated
+	 * commenting survives plugin upgrades and reactivation that would otherwise
+	 * leave the scheduled events cleared by the deactivation hook.
+	 */
+	public static function sync_schedules(): void {
+		foreach ( Boswell_Persona::get_all() as $persona ) {
+			$persona_id = $persona['id'] ?? '';
+			if ( '' === $persona_id ) {
+				continue;
+			}
+
+			$args        = array( $persona_id );
+			$is_enabled  = ! empty( $persona['cron_enabled'] );
+			$is_schedule = (bool) wp_next_scheduled( self::HOOK_NAME, $args );
+
+			if ( $is_enabled && ! $is_schedule ) {
+				$frequency = $persona['cron_frequency'] ?? 'daily';
+				if ( ! in_array( $frequency, self::FREQUENCIES, true ) ) {
+					$frequency = 'daily';
+				}
+				wp_schedule_event( time(), $frequency, self::HOOK_NAME, $args );
+			} elseif ( ! $is_enabled && $is_schedule ) {
+				wp_clear_scheduled_hook( self::HOOK_NAME, $args );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
## 問題

自動コメント機能が **2026-05-26 を最後に停止**していた（本番 takahashifumiki.com、ペルソナ Madame Claude）。原因は **スケジュール済み cron イベント `boswell_cron_comment` の消失**。

## 原因

`boswell.php` と `includes/class-cron.php` の設計上の穴：

1. cron は `Boswell_Persona::save()` → `Boswell_Cron::reschedule()` で **ペルソナ保存時にしか**張られない
2. `register_deactivation_hook` が `Boswell_Cron::unschedule()` を呼び、**無効化で全イベントを消去**
3. `register_activation_hook` は `migrate()` とメモリ初期化のみで **cron を張り直さない**
4. README の 2.0 アップグレード手順「`wp-content/plugins/boswell/` を削除してから入れ直す」を実行 → 無効化で cron 消去 → 2.0.x 有効化でも復活せず → ペルソナを再保存しない限り**永久に沈黙**

`cron_enabled=true / daily` の設定は本番に残っていたが、スケジュールだけが失われていた。

## 修正

`Boswell_Cron::sync_schedules()` を追加（冪等な突合）：

- `cron_enabled` でスケジュール欠落のペルソナ → 張り直す
- `cron_enabled=false` でスケジュール残存 → 消す
- frequency は `FREQUENCIES` で検証（不正値は `daily` にフォールバック）

呼び出し箇所：

- **activation hook** — 有効化・更新時に張り直す
- **`admin_init`** — wp-admin アクセス毎に自己修復（無効化フックで消えても次の管理画面表示で復活）

## 検証（ローカル Docker WP）

- ✅ PHPCS / PHPStan(level5) / `php -l` すべてパス
- ✅ 冪等性：`sync_schedules()` 2回実行 → 登録数 1（重複なし）
- ✅ 本番再現：`wp_clear_scheduled_hook()` で消去 → `do_action('admin_init')` で **復活確認**

## デプロイ後の本番復旧

本 PR をマージ・デプロイ後、wp-admin を一度開けば本番の cron も自動復活する（手動 eval 不要）。